### PR TITLE
feat: implement optimistic UI update for clip submission

### DIFF
--- a/myc-front/src/components/Clips.tsx
+++ b/myc-front/src/components/Clips.tsx
@@ -56,7 +56,7 @@ function Clip({
         />
       </div>
       <div className="absolute left-4 bottom-3 text-slate-600 select-none">
-        {formatDate(clip.createDatetime)}
+        {clip.createDatetime !== undefined ? formatDate(clip.createDatetime) : ""}
       </div>
     </div>
   );

--- a/myc-front/src/repository.ts
+++ b/myc-front/src/repository.ts
@@ -34,37 +34,42 @@ export const deleteClip = async (id: string) => {
   await updateDoc(docRef, { status: ClipStatus.Deleted });
 };
 
-export const addClip = async ({ text, type, file }: IClipCreate) => {
-  console.log(text, type, file);
-
+export const addClip = async ({
+  text,
+  type,
+  file,
+}: IClipCreate): Promise<{ id: string; createDatetime: number } | undefined> => {
   const user = auth.currentUser;
   if (user === null) {
     console.warn("User is not logged in");
     return;
   }
 
-  // 파일이 text, file 둘 다 없을 때
-  if (text === undefined && file && file?.size <= 0) {
+  const hasFile = file && file.size > 0;
+
+  if (!text && !hasFile) {
     console.warn("No dataText or file");
     return;
   }
 
+  const createDatetime = Date.now();
   const payload = {
     userId: user.uid,
     username: user.displayName,
-    createDatetime: Date.now(),
+    createDatetime,
     type,
     text: text || "",
     status: ClipStatus.Active,
   };
 
-  const doc = await addDoc(collection(db, "clips"), payload);
-  if (file) {
-    const locationRef = ref(storage, `clips/${user.uid}/${doc.id}`);
+  const docRef = await addDoc(collection(db, "clips"), payload);
+  if (hasFile) {
+    const locationRef = ref(storage, `clips/${user.uid}/${docRef.id}`);
     const result = await uploadBytes(locationRef, file);
     const url = await getDownloadURL(result.ref);
-    updateDoc(doc, { imageUrl: url });
+    updateDoc(docRef, { imageUrl: url });
   }
+  return { id: docRef.id, createDatetime };
 };
 
 export const getClips = async (

--- a/myc-front/src/routes/root.tsx
+++ b/myc-front/src/routes/root.tsx
@@ -5,6 +5,8 @@ import { ClipboardForm } from "../components/form";
 import useClip from "../hooks/useClip";
 import { addClip } from "../repository";
 import Header from "../components/Header";
+import { auth } from "../firebase";
+import { IClip } from "../types";
 
 export default function Root() {
   const mainRef = useRef<HTMLDivElement>(null);
@@ -26,13 +28,35 @@ export default function Root() {
       return;
     }
 
-    await addClip({
+    const user = auth.currentUser;
+    const tempId = `temp-${Date.now()}`;
+    const optimisticClip: IClip = {
+      id: tempId,
+      userId: user?.uid || "",
+      username: user?.displayName || "",
+      type: type.toString(),
+      text: dataText?.toString() || "",
+      pending: true,
+    };
+
+    setClips((prev) => [...prev, optimisticClip]);
+    window.scrollTo(0, document.body.scrollHeight);
+
+    const result = await addClip({
       text: dataText ? dataText.toString() : undefined,
       type: type.toString(),
       file: file ? (file as File) : undefined,
     });
 
-    await getClipsData();
+    if (result) {
+      setClips((prev) =>
+        prev.map((clip) =>
+          clip.id === tempId
+            ? { ...clip, id: result.id, createDatetime: result.createDatetime, pending: false }
+            : clip
+        )
+      );
+    }
   };
 
   useEffect(() => {

--- a/myc-front/src/types.ts
+++ b/myc-front/src/types.ts
@@ -15,6 +15,7 @@ export interface IClip extends IClipCreate {
   id: string;
   userId: string;
   username: string;
-  createDatetime: number;
+  createDatetime?: number;
   imageUrl?: string;
+  pending?: boolean;
 }


### PR DESCRIPTION
## Summary

- 텍스트 입력 시 서버 응답을 기다리지 않고 즉시 UI에 클립을 표시 (optimistic update)
- 서버 저장 완료 전까지 타임스탬프를 빈 상태로 표시하고, 저장 완료 후 날짜를 업데이트
- 텍스트 제출 시마다 빈 `File` 객체가 Firebase Storage에 업로드되던 버그 수정 (`storage/quota-exceeded` 오류 원인)

## Changes

- `types.ts`: `createDatetime`을 optional로 변경, `pending?: boolean` 필드 추가
- `repository.ts`: `addClip`이 `{ id, createDatetime }` 반환하도록 수정, `file.size > 0` 체크로 빈 파일 업로드 방지
- `root.tsx`: 제출 즉시 임시 클립을 state에 추가, 서버 응답 후 실제 id·날짜로 교체
- `Clips.tsx`: `createDatetime`이 없을 때 날짜 영역을 빈 문자열로 표시

## Test plan

- [ ] 텍스트 입력 후 제출 시 즉시 클립이 목록에 나타나는지 확인
- [ ] 서버 저장 완료 후 타임스탬프가 채워지는지 확인
- [ ] 이미지 업로드가 정상 동작하는지 확인
- [ ] 텍스트 제출 시 Storage 업로드가 발생하지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)