### PR TITLE
feat: support multiline input in clipboard form

### DIFF
--- a/myc-front/CLAUDE.md
+++ b/myc-front/CLAUDE.md
@@ -2,6 +2,10 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## Working Guidelines
+
+When receiving feature modification or implementation requests, if there are any ambiguous aspects regarding functionality (e.g., expected behavior, edge cases, scope, UI interaction), ask the user clarifying questions before proceeding with implementation.
+
 ## Commands
 
 ```bash

--- a/myc-front/src/components/Clips.tsx
+++ b/myc-front/src/components/Clips.tsx
@@ -88,7 +88,7 @@ function ClipCode({ text }: { text: string | undefined }) {
     }
   });
 
-  return <code>{content}</code>;
+  return <code className="whitespace-pre-wrap">{content}</code>;
 }
 
 const formatDate = (timestamp: number) => {

--- a/myc-front/src/components/form.tsx
+++ b/myc-front/src/components/form.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { ClipboardEvent, useRef, useState } from "react";
+import { ClipboardEvent, KeyboardEvent, useRef, useState } from "react";
 import { FaRegPaste } from "react-icons/fa6";
 import { IoIosSend, IoMdAdd } from "react-icons/io";
+
+const MIN_HEIGHT = 56;
 
 export function ClipboardForm({
   onSubmit,
@@ -15,6 +17,26 @@ export function ClipboardForm({
   const [type, setType] = useState<"text" | "image">("text");
   const fileInputRef = useRef<HTMLInputElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const adjustHeight = () => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    const style = getComputedStyle(textarea);
+    const lineHeight = parseFloat(style.lineHeight);
+    const paddingTop = parseFloat(style.paddingTop);
+    const paddingBottom = parseFloat(style.paddingBottom);
+    const maxHeight = lineHeight * 5 + paddingTop + paddingBottom;
+    textarea.style.height = "auto";
+    textarea.style.height =
+      Math.min(Math.max(textarea.scrollHeight, MIN_HEIGHT), maxHeight) + "px";
+  };
+
+  const resetHeight = () => {
+    const textarea = textareaRef.current;
+    if (!textarea) return;
+    textarea.style.height = MIN_HEIGHT + "px";
+  };
 
   const submitText = (text: string) => {
     const formData = new FormData();
@@ -50,7 +72,7 @@ export function ClipboardForm({
     }
   };
 
-  const handlePaste = (event: ClipboardEvent<HTMLInputElement>) => {
+  const handlePaste = (event: ClipboardEvent<HTMLTextAreaElement>) => {
     const items = event.clipboardData?.items;
     Array.from(items || []).forEach((item) => {
       if (item.type.includes("image")) {
@@ -66,15 +88,26 @@ export function ClipboardForm({
           submitImage(blob);
           setData("");
           setImageData("");
+          resetHeight();
         }
       } else if (item.type.includes("text/plain")) {
         item.getAsString((str) => {
           submitText(str);
           setData("");
           setImageData("");
+          resetHeight();
         });
       }
     });
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key !== "Enter") return;
+    const isMobile = window.matchMedia("(pointer: coarse)").matches;
+    if (!isMobile && !e.shiftKey) {
+      e.preventDefault();
+      if (data.trim()) formRef.current?.requestSubmit();
+    }
   };
 
   return (
@@ -84,6 +117,7 @@ export function ClipboardForm({
           e.preventDefault();
           if (onSubmit) onSubmit(new FormData(e.target as HTMLFormElement));
           setData("");
+          resetHeight();
         }}
         ref={formRef}
       >
@@ -91,7 +125,7 @@ export function ClipboardForm({
           <div>
             {image !== null ? <img src={image} alt={"preview"} /> : null}
           </div>
-          <div className="flex justify-between">
+          <div className="flex justify-between items-stretch">
             <input type="hidden" name="type" value={type} />
             <input
               aria-label="fileInput"
@@ -107,34 +141,40 @@ export function ClipboardForm({
             />
             <div
               onClick={() => fileInputRef.current?.click()}
-              className="w-14 flex justify-center items-center cursor-pointer border"
+              className="w-14 flex justify-center items-center cursor-pointer border flex-shrink-0"
             >
               <IoMdAdd className="text-lg" />
             </div>
             <div className="border flex-grow">
-              <input
-                onChange={(e) => setData(e.target.value)}
+              <textarea
+                ref={textareaRef}
+                onChange={(e) => {
+                  setData(e.target.value);
+                  adjustHeight();
+                }}
                 onPaste={handlePaste}
+                onKeyDown={handleKeyDown}
                 value={data}
                 id="dataInput"
                 placeholder="Input your data"
-                type="text"
                 name="data"
-                className="h-14 w-full px-3 py-2 text-sm leading-tight bg-transparent text-white outline-none appearance-none focus:outline-none"
+                rows={1}
+                style={{ height: MIN_HEIGHT + "px" }}
+                className="w-full px-3 py-2 text-sm leading-tight bg-transparent text-white outline-none appearance-none focus:outline-none resize-none overflow-y-auto"
               />
             </div>
 
             {data !== "" ? (
               <div
                 onClick={() => formRef.current?.requestSubmit()}
-                className="w-14 flex justify-center items-center cursor-pointer border"
+                className="w-14 flex justify-center items-center cursor-pointer border flex-shrink-0"
               >
                 <IoIosSend className="text-lg" />
               </div>
             ) : (
               <div
                 onClick={submitClipboard}
-                className="w-14 flex justify-center items-center cursor-pointer border"
+                className="w-14 flex justify-center items-center cursor-pointer border flex-shrink-0"
               >
                 <FaRegPaste className="text-lg" />
               </div>


### PR DESCRIPTION
## Summary

- 클립보드 입력창을 `<input type="text">`에서 자동 높이 조절 `<textarea>`로 교체
- PC에서 `Enter` = 제출, `Shift+Enter` = 개행; 모바일(`pointer: coarse`)에서 `Enter` = 개행
- 입력 내용이 늘어나면 최대 5줄까지 입력창 높이가 자동으로 확장
- 클립 표시 시 `whitespace-pre-wrap`으로 개행 문자를 정상 렌더링
- 좌우 버튼이 `items-stretch`로 textarea 높이에 맞게 함께 늘어나도록 수정

## Test plan

- [ ] PC: 텍스트 입력 후 `Enter` 키로 제출되는지 확인
- [ ] PC: `Shift+Enter`로 개행 입력 후 전송 시 개행이 유지되는지 확인
- [ ] 모바일: `Enter` 키로 개행이 입력되는지 확인
- [ ] 입력 내용이 길어질 때 입력창이 최대 5줄까지 늘어나는지 확인
- [ ] 5줄 초과 시 입력창 높이가 고정되고 내부 스크롤이 동작하는지 확인
- [ ] 제출 후 입력창 높이가 초기 높이로 복원되는지 확인
- [ ] 좌우 버튼이 입력창 높이에 맞게 늘어나는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)